### PR TITLE
Security Fix for tokio-rustls Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,11 +48,12 @@ dependencies = [
  "ring 0.16.20",
  "rocksdb",
  "rug",
+ "rustls-pemfile 2.0.0",
  "serde 1.0.195",
  "serde_json",
  "sha3",
  "tokio",
- "tokio-rustls 0.22.0",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util 0.6.10",
  "tracing",
@@ -425,12 +426,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -2406,14 +2401,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
- "base64 0.13.1",
  "log",
  "ring 0.16.20",
- "sct 0.6.1",
+ "sct",
  "webpki",
 ]
 
@@ -2426,7 +2420,7 @@ dependencies = [
  "log",
  "ring 0.17.7",
  "rustls-webpki",
- "sct 0.7.1",
+ "sct",
 ]
 
 [[package]]
@@ -2437,6 +2431,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.5",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64 0.21.5",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
 
 [[package]]
 name = "rustls-webpki"
@@ -2489,16 +2499,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
 
 [[package]]
 name = "sct"
@@ -2862,11 +2862,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.19.1",
+ "rustls 0.20.9",
  "tokio",
  "webpki",
 ]
@@ -3281,7 +3281,7 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "scoped-tls",
  "serde 1.0.195",
  "serde_json",
@@ -3391,12 +3391,12 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0.104", features = ["derive"] }
 sha3 = "0.9.1"
 serde_json = "1.0.61"
 tokio = { version = "1.7.1", features = ["full"] }
-tokio-rustls = "0.22.0"
+tokio-rustls = "0.23.0"
 tokio-util = { version = "0.6.7", features = ["full"] }
 tokio-stream = "0.1.6"
 tracing = "0.1.13"
@@ -42,6 +42,7 @@ tracing-futures = "0.2.3"
 warp = { version = "0.3.1", features = ["tls"] }
 url = "2.4.1"
 trust-dns-resolver = "0.23.2"
+rustls-pemfile = "2.0.0"
 
 [features]
 mock = []

--- a/src/comms_handler/error.rs
+++ b/src/comms_handler/error.rs
@@ -3,7 +3,7 @@ use crate::interfaces::NodeType;
 use std::net::SocketAddr;
 use std::{error::Error, fmt, io};
 use tokio::sync::mpsc;
-use tokio_rustls::rustls::TLSError;
+use tokio_rustls::rustls::Error as TLSError;
 use tokio_rustls::webpki;
 
 #[derive(Debug)]

--- a/src/comms_handler/error.rs
+++ b/src/comms_handler/error.rs
@@ -32,6 +32,8 @@ pub enum CommsError {
     Serialization(bincode::Error),
     /// MPSC channel error.
     ChannelSendError(mpsc::error::SendError<Event>),
+    /// Webpki error
+    WebpkiError(webpki::Error),
 }
 
 #[derive(Debug)]
@@ -55,6 +57,7 @@ impl fmt::Display for CommsError {
             Self::PeerIncompatible(info) => write!(f, "Peer incompatible: {info:?}"),
             Self::Serialization(err) => write!(f, "Serialization error: {err}"),
             Self::ChannelSendError(err) => write!(f, "MPSC channel send error: {err}"),
+            Self::WebpkiError(err) => write!(f, "Webpki error: {err}"),
         }
     }
 }
@@ -74,6 +77,7 @@ impl Error for CommsError {
             Self::PeerIncompatible(_) => None,
             Self::Serialization(err) => Some(err),
             Self::ChannelSendError(err) => Some(err),
+            Self::WebpkiError(err) => Some(err),
         }
     }
 }
@@ -104,6 +108,6 @@ impl From<TLSError> for CommsError {
 
 impl From<webpki::Error> for CommsError {
     fn from(other: webpki::Error) -> Self {
-        Self::TlsError(TLSError::WebPKIError(other))
+        Self::WebpkiError(other)
     }
 }

--- a/src/comms_handler/tcp_tls.rs
+++ b/src/comms_handler/tcp_tls.rs
@@ -7,9 +7,9 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::io::Cursor;
 use std::net::SocketAddr;
-use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::fmt;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
@@ -18,7 +18,7 @@ use tokio_rustls::rustls::{
     Certificate, ClientConfig, CommonState, PrivateKey, RootCertStore, ServerConfig 
 };
 use tokio_rustls::rustls::client::ServerName;
-use tokio_rustls::webpki::EndEntityCert;
+use tokio_rustls::webpki::{DnsNameRef, EndEntityCert};
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 use tokio_stream::Stream;
 
@@ -191,6 +191,14 @@ pub struct TcpTlsConnector {
     tls_connector: Option<TlsConnector>,
 }
 
+impl fmt::Debug for TcpTlsConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TcpTlsConnector")
+            .field("socket_name_mapping", &self.socket_name_mapping)
+            .finish()
+    }
+}
+
 impl TcpTlsConnector {
     pub fn new(config: &TcpTlsConfig) -> Result<Self> {
         let tls_connector = if config.use_tls {
@@ -231,7 +239,8 @@ impl TcpTlsConnector {
 
 fn load_certs(pem: &str) -> Vec<TlsCertificate> {
     let mut final_certs = Vec::new();
-    let init_certs = certs(&mut Cursor::new(pem));
+    let mut binding = Cursor::new(pem);
+    let init_certs = certs(&mut binding);
 
     for cert in init_certs {
         if cert.is_ok() {
@@ -244,7 +253,8 @@ fn load_certs(pem: &str) -> Vec<TlsCertificate> {
 
 fn load_keys(pem: &str) -> Vec<PrivateKey> {
     let mut final_keys = Vec::new();
-    let init_keys = pkcs8_private_keys(&mut Cursor::new(pem));
+    let mut binding = Cursor::new(pem);
+    let init_keys = pkcs8_private_keys(&mut binding);
 
     for key in init_keys {
         if key.is_ok() {
@@ -277,7 +287,8 @@ fn new_root_certs(trusted_pem_certs: &[String]) -> Result<RootCertStore> {
 }
 
 fn new_server_config(config: &TcpTlsConfig) -> Result<ServerConfig> {
-    let root_store = new_root_certs(&config.trusted_pem_certs)?;
+    // TODO: Handle root_store
+    // let root_store = new_root_certs(&config.trusted_pem_certs)?;
     let certs = load_certs(&config.pem_certs);
     let mut keys = load_keys(&config.pem_pkcs8_private_keys);
 
@@ -297,7 +308,7 @@ fn new_client_config(config: &TcpTlsConfig) -> Result<ClientConfig> {
     let certs = load_certs(&config.pem_certs);
     let mut keys = load_keys(&config.pem_pkcs8_private_keys);
 
-    let mut client_config = ClientConfig::builder()
+    let client_config = ClientConfig::builder()
         .with_safe_default_cipher_suites()
         .with_safe_default_kx_groups()
         .with_safe_default_protocol_versions()
@@ -324,8 +335,8 @@ impl TcpTlsStream {
 
     pub fn peer_tls_certificate(&self) -> Option<TlsCertificate> {
         match self {
-            Self::Client(tls, _) => get_first_certificate(&*tls.into_inner().1),
-            Self::Server(tls, _) => get_first_certificate(&*tls.into_inner().1),
+            Self::Client(tls, _) => get_first_certificate(tls.get_ref().1),
+            Self::Server(tls, _) => get_first_certificate(tls.get_ref().1),
             Self::RawTcp(_, _) => None,
         }
     }
@@ -385,14 +396,11 @@ pub fn verify_is_valid_for_dns_names<'a>(
     tls_names: impl Iterator<Item = &'a str>,
 ) -> Result<()> {
     let domains: std::result::Result<Vec<_>, _> =
-        tls_names.map(|v| ServerName::try_from(v)).collect();
+        tls_names.map(|v| DnsNameRef::try_from_ascii_str(v)).collect();
     let domains = domains.map_err(|_| CommsError::ConfigError("invalid dnsname"))?;
 
     let cert = EndEntityCert::try_from(cert.0.as_slice()).unwrap();
-    cert.verify_is_valid_for_at_least_one_dns_name(domains.iter().filter(|e| match e {
-        ServerName::DnsName(_) => true,
-        _ => false,
-    }).copied())?;
+    cert.verify_is_valid_for_at_least_one_dns_name(domains.iter().copied())?;
     Ok(())
 }
 
@@ -402,7 +410,7 @@ pub fn verify_is_valid_for_dns_names<'a>(
 /// ### Arguments
 /// 
 /// * `session_conn` - The TLS session connection
-fn get_first_certificate(session_conn: &impl Deref<Target=CommonState>) -> Option<TlsCertificate> {
+fn get_first_certificate(session_conn: &CommonState) -> Option<TlsCertificate> {
     match session_conn.peer_certificates() {
         Some(certs) => certs.first().cloned(),
         None => None,

--- a/src/compute_raft.rs
+++ b/src/compute_raft.rs
@@ -801,7 +801,7 @@ impl ComputeRaft {
     pub async fn propose_timestamp(&mut self) {
         if self.first_raft_peer {
             println!("Proposing timestamp as first peer");
-            self.propose_item(&ComputeRaftItem::Timestamp(self.timestamp.clone()))
+            self.propose_item(&ComputeRaftItem::Timestamp(self.timestamp))
                 .await;
         }
     }
@@ -1340,7 +1340,7 @@ impl ComputeConsensused {
         let b_num = self.block_pipeline.current_block_num().unwrap();
 
         block.header.previous_hash = Some(previous_hash);
-        block.header.timestamp = self.timestamp.clone();
+        block.header.timestamp = self.timestamp;
         block.header.b_num = b_num;
         block.set_txs_merkle_root_and_hash().await;
     }


### PR DESCRIPTION
## Description
Fixes the security vulnerability that arose from using `tokio-rustls` dependency at v0.22.0. Bumping to 0.23.0 is the minimum required change, but is a breaking change and therefore required numerous adjustments to the structure of TLS certificate handling.

## Changelog

- Bumps `tokio-rustls` to 0.23.0
- Adds `rustls-pemfile` as a separate dependency
- Restructures the config of both client and server TLS instances

**NOTE: The new server config doesn't have an obvious way to integrate the root store. This will need to be checked in a future update**

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Requested Reviewers
@BarryBoot 