### PR TITLE
Easy local startup

### DIFF
--- a/.docker/conf/node_settings.toml
+++ b/.docker/conf/node_settings.toml
@@ -28,13 +28,13 @@ user_setup_tx_max_count = 100000
 
 #first node is leader
 [[compute_nodes]]
-address = "http://localhost:12300"
+address = "http://network-a-compute-node-1:12300"
 
 [[storage_nodes]]
-address = "http://localhost:12330"
+address = "http://network-a-storage-node-1:12330"
 
 [[miner_nodes]]
-address = "http://localhost:12340"
+address = "http://network-a-miner-node-1:12340"
 
 [[user_nodes]]
-address = "http://localhost:12360"
+address = "http://network-a-user-node-1:12360"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
-name: build-deploy
+name: build-scan
 on: 
-  push:
+  pull_request:
     branches: 
       - main
-      - enable_domain_resolution
+      - develop
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: build-scan
 on: 
-  pull_request:
+  push:
     branches: 
       - main
       - develop
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   build: 
-    uses: ablockofficial/platform/.github/workflows/build.yml@main
+    uses: ablockofficial/workflows/.github/workflows/build.yml@main
     with: 
       REGISTRY:  ${{ vars.REGISTRY }}
       REPOSITORY: ${{ vars.REPOSITORY }}
   scan-image:
-    uses: ablockofficial/platform/.github/workflows/scan-image.yml@main
+    uses: ablockofficial/workflows/.github/workflows/scan-image.yml@main
     secrets: inherit
     needs: build
     with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3'
+services:
+
+  a-compute-node: &node-default
+    image: network
+    environment:
+      RUST_LOG: info,debug
+    init: true
+    ports: 
+      - '12300:12300'
+      - '3003:3003'
+    volumes:  
+      - /tmp/compute:/src
+    command: compute
+  
+  a-storage-node:
+    <<: *node-default
+    ports:
+      - '12330:12330'
+      - '3001:3001'
+    volumes:  
+      - /tmp/storage:/src
+    command: storage
+
+  a-miner-node:
+    <<: *node-default
+    depends_on: 
+      - a-compute-node
+      - a-storage-node
+    ports:
+      - '12340:12340'
+      - '3004:3004'
+    volumes:  
+      - /tmp/miner:/src
+    command: miner
+
+  # a-alice-node:
+  #   <<: *node-default
+  #   ports:
+  #     - '12360:12360'
+  #   command: node user
+
+  # a-bob-node:
+  #   <<: *node-default
+  #   ports:
+  #     - '12361:12361'
+  #   command: node user


### PR DESCRIPTION
This adds:

- docker-compose for quick local nodes
- default config that works locally
- builds to run on push, test to run on pull requests

docker-compose does require a locally built image:
docker build -t network .