### PR TITLE
set glibc-dynamic to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN cargo build --release
 
 # Use distroless
-FROM cgr.dev/chainguard/glibc-dynamic@sha256:112c81208f12acaa8568222edd3083cf16fa50392afce7e2f71737e42ed3dddc
+FROM cgr.dev/chainguard/glibc-dynamic:latest
 
 USER nonroot
 


### PR DESCRIPTION
## Description
There are some new base OS vulnerabilities found that are fixed by this update.
It looks like chainguard's model has changed to allow only :latest or :latest-dev tags in the open.
Trivy will hate on running :latest but in a chainguard environment this should be fine.

Fixes # (issue number)
86bxffp9q

## Changelog

- List the changes to the codebase that this PR introduces

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] My code follows the project's coding standards and style guidelines.
- [ ] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Screenshots (if applicable)
If the changes affect the UI or have visual effects, please provide screenshots or GIFs showcasing the changes.

## Additional Context (if applicable)
Add any additional context or information about the changes that may be helpful in understanding the pull request.

## Related Issues (if applicable)
If this pull request is related to any existing issues, please list them here.

## Requested Reviewers
Mention any specific individuals or teams you would like to request a review from.