### PR TITLE
Changed '/blockchain_entry' route to retrun mutiple items

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -405,14 +405,14 @@ pub async fn get_total_supply(
 
 //======= POST HANDLERS =======//
 
-/// Post to retrieve an item from the blockchain db by hash key
+/// Post to retrieve items from the blockchain db by hash key
 pub async fn post_blockchain_entry_by_key(
     db: Arc<Mutex<SimpleDb>>,
-    key: String,
+    keys: Vec<String>,
     route: &'static str,
     call_id: String,
 ) -> Result<JsonReply, JsonReply> {
-    get_json_reply_stored_value_from_db(db, &key, true, call_id, route)
+    get_json_reply_items_from_db(db, keys, route, call_id)
 }
 
 /// Post to batch retrieve multiple transactions from the blockchain db by hash keys

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -429,7 +429,8 @@ pub fn calculate_reward(current_circulation: TokenAmount) -> TokenAmount {
     }
 
     TokenAmount(
-        ((TOTAL_TOKENS - current_circulation.0) >> REWARD_ISSUANCE_VAL) + smoothing_value_as_token_amount
+        ((TOTAL_TOKENS - current_circulation.0) >> REWARD_ISSUANCE_VAL)
+            + smoothing_value_as_token_amount,
     )
 }
 


### PR DESCRIPTION
## Description
Changed '/blockchain_entry' route to accept an array of hashes and retrun mutiple items.

## Changelog
- Changed `post_blockchain_entry_by_key` function to take Vec<String> instead of a &str
- Changed `get_json_reply_stored_value_from_db` with `get_json_reply_items_from_db` in `post_blockchain_entry_by_key`

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [ ] I have added/updated relevant tests to ensure the changes are properly covered.
- [ ] I have checked for and resolved any merge conflicts.
- [x] My commits have clear and descriptive messages.

## Additional Context (if applicable)
Since transaction_by_key was disabled, there was no way to fetch multiple transactions in one call. It also allows to fetch mutiple blocks by hash.